### PR TITLE
Update contributing guidelines to reflect correct repository name in …

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Thank you for your interest in contributing to this project! Please read the fol
 1. **Fork the repository**: Click the "Fork" button on GitHub to create a copy of the project under your account.
 2. **Clone to your local machine**:
     ```bash
-    git clone https://github.com/<your-username>/github-profile-badges.git
+    git clone https://github.com/<your-username>/github-profile-achievements.git
     ```
 3. **Create a new branch**:
     ```bash
@@ -33,11 +33,11 @@ Thank you for your interest in contributing to this project! Please read the fol
 -   Clearly explain your changes in the Pull Request description.
 -   Follow the project's coding style and guidelines.
 -   Test your code before submitting.
--   For suggestions or bug reports, please open an [Issue](https://github.com/codeprovn/github-profile-badges/issues).
+-   For suggestions or bug reports, please open an [Issue](https://github.com/codeprovn/github-profile-achievements/issues).
 
 ## Contact
 
-If you have questions, join [Discussions](https://github.com/codeprovn/github-profile-badges/discussions) or email: lienhe@code.pro.vn.
+If you have questions, join [Discussions](https://github.com/codeprovn/github-profile-achievements/discussions) or email: lienhe@code.pro.vn.
 
 ---
 

--- a/CONTRIBUTING.vi.md
+++ b/CONTRIBUTING.vi.md
@@ -9,7 +9,7 @@ Cảm ơn bạn đã quan tâm tới việc đóng góp cho dự án này! Vui l
 1. **Fork repository**: Nhấn nút "Fork" trên GitHub để tạo một bản sao của dự án về tài khoản của bạn.
 2. **Clone về máy**:
     ```bash
-    git clone https://github.com/<ten-tai-khoan-cua-ban>/github-profile-badges.git
+    git clone https://github.com/<ten-tai-khoan-cua-ban>/github-profile-achievements.git
     ```
 3. **Tạo nhánh mới**:
     ```bash
@@ -33,11 +33,11 @@ Cảm ơn bạn đã quan tâm tới việc đóng góp cho dự án này! Vui l
 -   Giải thích rõ ràng về các thay đổi trong mô tả Pull Request.
 -   Tuân thủ phong cách mã nguồn và quy tắc của dự án.
 -   Kiểm tra kỹ mã nguồn trước khi gửi Pull Request.
--   Nếu muốn đóng góp ý tưởng hoặc báo lỗi, vui lòng mở một [Issue](https://github.com/codeprovn/github-profile-badges/issues).
+-   Nếu muốn đóng góp ý tưởng hoặc báo lỗi, vui lòng mở một [Issue](https://github.com/codeprovn/github-profile-achievements/issues).
 
 ## Liên hệ
 
-Nếu có thắc mắc, hãy liên hệ qua [Discussions](https://github.com/codeprovn/github-profile-badges/discussions) hoặc email: lienhe@code.pro.vn.
+Nếu có thắc mắc, hãy liên hệ qua [Discussions](https://github.com/codeprovn/github-profile-achievements/discussions) hoặc email: lienhe@code.pro.vn.
 
 ---
 


### PR DESCRIPTION
This pull request updates project references in the contribution guidelines to reflect the new repository name, changing all instances from `github-profile-badges` to `github-profile-achievements`. These changes ensure that contributors are directed to the correct repository and its associated resources in both English and Vietnamese documentation.

Repository reference updates:

* Updated the clone URLs in both `CONTRIBUTING.md` and `CONTRIBUTING.vi.md` to use `github-profile-achievements` instead of `github-profile-badges`. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L12-R12) [[2]](diffhunk://#diff-c3e2555d743aeeb28102adbf54010be627efb21d419e84467b90491ed882687eL12-R12)
* Changed the Issue and Discussions links in both contribution guides to point to the new repository, ensuring contributors are directed to the correct location for reporting issues and joining discussions. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L36-R40) [[2]](diffhunk://#diff-c3e2555d743aeeb28102adbf54010be627efb21d419e84467b90491ed882687eL36-R40)