### PR TITLE
Update README.vi.md to enhance content structure, improve clarity, an…

### DIFF
--- a/README.vi.md
+++ b/README.vi.md
@@ -1,14 +1,65 @@
-# Huy hiệu hồ sơ GitHub
+# Thành Tích Hồ Sơ GitHub
 
-Chào mừng bạn đến với dự án Huy hiệu hồ sơ GitHub!
+[🇺🇸](./README.md) | 🇻🇳
 
-<!-- Ngôn ngữ khác -->
-
-## 🌐 Ngôn ngữ khác
-
--   [🇬🇧 English](README.md)
-<!-- Thêm ngôn ngữ khác nếu cần -->
+> Hướng dẫn đầy đủ về các huy hiệu và thành tích trên hồ sơ GitHub. Tìm hiểu cách để nhận mỗi huy hiệu và các yêu cầu cho từng cấp độ.
 
 ## Giới thiệu
 
-(Nội dung tiếng Việt ở đây...)
+Dự án này nhằm mục đích tổng hợp và trình bày tất cả các thành tích và huy hiệu trên hồ sơ GitHub trong một tài liệu duy nhất, dễ dàng tra cứu. Mục tiêu là giúp cộng đồng nhanh chóng tìm thấy thông tin về mỗi huy hiệu, các yêu cầu để nhận chúng, và các cấp độ của chúng. Dự án này được dựa trên nghiên cứu và lấy cảm hứng từ một số kho mã nguồn mở nổi tiếng.
+
+> **⚠️ Lưu ý:** Đây là một tài liệu tham khảo, không phải là danh sách chính thức do GitHub cung cấp. Các yêu cầu về huy hiệu và chi tiết thành tích có thể thay đổi khi GitHub cập nhật hệ thống của mình.
+
+---
+
+## Danh sách các Huy hiệu
+
+Bảng dưới đây liệt kê tất cả các huy hiệu có sẵn trên GitHub, tên của chúng, liệu chúng có thể nhận được hiện tại hay không, và cách để nhận mỗi huy hiệu.
+
+| Huy hiệu | Tên | Có thể nhận? | Cách nhận |
+| --- | --- | --- | --- |
+| ![Heart On Your Sleeve](/images/achievements/default/heart-on-your-sleeve.png) | Heart On Your Sleeve | `🔜 Đang thử nghiệm` | Người dùng có thể nhận huy hiệu này bằng cách bày tỏ cảm xúc với emoji ❤️ trên GitHub |
+| ![Open Sourcerer](/images/achievements/default/open-sourcerer.png) | Open Sourcerer |  `🔜 Đang thử nghiệm` | Có thể nhận được nếu người dùng có Pull Request được hợp nhất trong hơn 1 kho mã nguồn công khai |
+| ![Starstruck](/images/achievements/default/starstruck.png) | Starstruck | `✅ Có` | Huy hiệu này được trao cho người có một trong các kho mã nguồn của họ đạt 16 sao. |
+| ![Quickdraw](/images/achievements/default/quickdraw.png) | Quickdraw | `✅ Có` | Có thể nhận bằng cách đóng một Pull Request hoặc Issue trong vòng 5 phút sau khi nó được mở. (Bạn có thể tự đóng issue của mình) |
+| ![Pair Extraordinaire](/images/achievements/default/pair-extraordinaire.png) | Pair Extraordinaire | `✅ Có` | Người dùng có thể nhận huy hiệu này bằng cách [đồng tác giả](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) trong một pull request đã được hợp nhất. (Yêu cầu ứng dụng GitHub Desktop) |
+| ![Pull Shark](/images/achievements/default/pull-shark.png) | Pull Shark | `✅ Có` | Bạn có thể nhận huy hiệu này bằng cách hợp nhất 2 pull request. |
+| ![Galaxy Brain](/images/achievements/default/galaxy-brain.png) | Galaxy Brain | `✅ Có` | Người dùng có thể nhận huy hiệu này bằng cách có 2 câu trả lời được chấp nhận trên diễn đàn [Community Discussions](https://github.com/orgs/community/discussions/). |
+| ![YOLO](/images/achievements/default/yolo.png) | YOLO | `✅ Có` | Người dùng có thể nhận huy hiệu này bằng cách hợp nhất một pull request mà không cần review (Điều này yêu cầu 1 người dùng và 1 người review) |
+| ![Public Sponsor](/images/achievements/default/public-sponsor.png) | Public Sponsor | `✅ Có` | Tài trợ cho các dự án mã nguồn mở qua [GitHub Sponsors](https://github.com/sponsors) |
+| ![Arctic Code Vault Contributor](/images/achievements/default/arctic-code-vault-contributor.png) | Arctic Code Vault Contributor | `❌ Không` | Trước đây có thể nhận bằng cách đóng góp mã nguồn vào các kho lưu trữ trong [Chương trình Lưu trữ 2020](https://archiveprogram.github.com/) |
+| ![Mars 2020 Contributor](/images/achievements/default/mars-2020-contributor.png) | Mars 2020 Contributor | `❌ Không` | Được trao nếu người dùng đã đóng góp mã nguồn vào các kho lưu trữ trong [Nhiệm vụ Mars 2020](https://github.com/readme/nasa-ingenuity-helicopter) |
+
+## Các Cấp Độ Thành Tích
+
+Một số thành tích có nhiều cấp độ, bao gồm mặc định, đồng, bạc và vàng. Bảng sau đây mô tả mỗi cấp độ và các yêu cầu tương ứng.
+
+| Thành tích | Mặc định | Đồng | Bạc | Vàng |
+| :-: | :-: | :-: | :-: | :-: |
+| **Heart On Your Sleeve** | <img src="/images/achievements/default/heart-on-your-sleeve.png" width="60px"><br>(?) | <img src="/images/achievements/tiers/heart-on-your-sleeve/bronze.png" width="60px"><br>(?) | <img src="/images/achievements/tiers/heart-on-your-sleeve/silver.png" width="60px"><br>(?) | <img src="/images/achievements/tiers/heart-on-your-sleeve/gold.png" width="60px"><br>(?) |
+| **Open Sourcerer** | <img src="/images/achievements/default/open-sourcerer.png" width="60px"><br>(?) | <img src="/images/achievements/tiers/open-sourcerer/bronze.png" width="60px"><br>(?) | <img src="/images/achievements/tiers/open-sourcerer/silver.png" width="60px"><br>(?) | <img src="/images/achievements/tiers/open-sourcerer/gold.png" width="60px"><br>(?) |
+| **Starstruck** | <img src="/images/achievements/default/starstruck.png" width="60px"><br>16 sao | <img src="/images/achievements/tiers/starstruck/bronze.png" width="60px"><br>128 sao | <img src="/images/achievements/tiers/starstruck/silver.png" width="60px"><br>512 sao | <img src="/images/achievements/tiers/starstruck/gold.png" width="60px"><br>4096 sao |
+| **Quickdraw** | <img src="/images/achievements/default/quickdraw.png" width="60px"><br>1 lần đóng nhanh | - | - | - |
+| **Pair Extraordinaire** | <img src="/images/achievements/default/pair-extraordinaire.png" width="60px"><br>1 commit | <img src="/images/achievements/tiers/pair-extraordinaire/bronze.png" width="60px"><br>10 commit | <img src="/images/achievements/tiers/pair-extraordinaire/silver.png" width="60px"><br>24 commit | <img src="/images/achievements/tiers/pair-extraordinaire/gold.png" width="60px"><br>48 commit |
+| **Pull Shark** | <img src="/images/achievements/default/pull-shark.png" width="60px"><br>2 pull request | <img src="/images/achievements/tiers/pull-shark/bronze.png" width="60px"><br>16 pull request | <img src="/images/achievements/tiers/pull-shark/silver.png" width="60px"><br>128 pull request | <img src="/images/achievements/tiers/pull-shark/gold.png" width="60px"><br>1024 pull request |
+| **Galaxy Brain** | <img src="/images/achievements/default/galaxy-brain.png" width="60px"><br>2 câu trả lời | <img src="/images/achievements/tiers/galaxy-brain/bronze.png" width="60px"><br>8 câu trả lời | <img src="/images/achievements/tiers/galaxy-brain/silver.png" width="60px"><br>16 câu trả lời | <img src="/images/achievements/tiers/galaxy-brain/gold.png" width="60px"><br>32 câu trả lời |
+| **YOLO** | <img src="/images/achievements/default/yolo.png" width="60px"><br>1 lần hợp nhất không review | - | - | - |
+| **Public Sponsor** | <img src="/images/achievements/default/public-sponsor.png" width="60px"><br>1 lần tài trợ | - | - | - |
+| **Arctic Code Vault Contributor** | <img src="/images/achievements/default/arctic-code-vault-contributor.png" width="60px"><br>Huy hiệu cũ | - | - | - |
+| **Mars 2020 Contributor** | <img src="/images/achievements/default/mars-2020-contributor.png" width="60px"><br>Huy hiệu cũ | - | - | - |
+
+---
+
+## Mục đích Dự án
+
+Dự án này dành cho mục đích giáo dục và tham khảo, giúp người dùng GitHub hiểu rõ hơn về hệ thống huy hiệu và thành tích. Nếu bạn phát hiện bất kỳ thông tin không chính xác hoặc thiếu sót nào, vui lòng đóng góp hoặc mở một issue để giúp cải thiện tài liệu này.
+
+## Tài liệu tham khảo
+
+Dự án này được phát triển bằng cách tham khảo và học hỏi từ các dự án cộng đồng xuất sắc sau:
+
+- [Thinkright20/Profile-Badges](https://github.com/Thinkright20/Profile-Badges) – Danh sách toàn diện các huy hiệu, cấp độ và các biến thể màu da.
+- [drknzz/GitHub-Achievements](https://github.com/drknzz/GitHub-Achievements) – Bộ sưu tập hình ảnh, chi tiết về thành tích, cấp độ và các biến thể.
+- [Schweinepriester/github-profile-achievements](https://github.com/Schweinepriester/github-profile-achievements/) – Danh sách thành tích, lịch sử cập nhật, nguồn cảm hứng và các liên kết hữu ích.
+
+> Xin chân thành cảm ơn các tác giả và những người đóng góp trong cộng đồng đã cung cấp thông tin, hình ảnh, nội dung và nguồn cảm hứng cho dự án này.


### PR DESCRIPTION
This pull request makes significant improvements to the Vietnamese `README.vi.md` documentation for GitHub profile achievements. The changes focus on expanding the content, organizing information about badges and achievement tiers, and clarifying the project's purpose and sources.

Content expansion and organization:

* Added a comprehensive introduction explaining the purpose of the project and its intended audience, making the documentation more user-friendly and informative.
* Provided a detailed table listing all available GitHub badges, their names, current availability, and instructions for how to earn each badge.
* Introduced a new section describing achievement tiers (default, bronze, silver, gold) for badges that support levels, including requirements for each tier.

Project purpose and references:

* Clarified that the document is for educational and reference purposes, not an official GitHub resource, and encouraged community contributions to improve accuracy.
* Included a references section acknowledging other community projects that inspired and informed this documentation.